### PR TITLE
notEmpty() is deprecated

### DIFF
--- a/src/Validation/ConfigValidator.php
+++ b/src/Validation/ConfigValidator.php
@@ -26,6 +26,6 @@ class ConfigValidator extends GlobalValidator
         parent::__construct();
         $this
             ->requirePresence('secret')
-            ->notEmpty('secret', __d('recaptcha', 'A secret should not be blank.'));
+            ->notEmptyString('secret', __d('recaptcha', 'A secret should not be blank.'));
     }
 }


### PR DESCRIPTION
Update for CakePHP 4
Resolves Issue #15