### PR TITLE
`Validator::errors()` is deprecated. Use `Validator::validate()` instead.

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,7 +17,7 @@ if ($config == null) {
 // Validate the Configure Data
 $validator = new ConfigValidator();
 
-$errors = $validator->errors(Configure::read('Recaptcha'));
+$errors = $validator->validate(Configure::read('Recaptcha'));
 
 if (!empty($errors)) {
     $errMsg = '';

--- a/src/View/Helper/RecaptchaHelper.php
+++ b/src/View/Helper/RecaptchaHelper.php
@@ -95,7 +95,7 @@ class RecaptchaHelper extends Helper
 
         // Validate the Configure Data
         $validator = new RecaptchaValidator();
-        $errors = $validator->errors($options);
+        $errors = $validator->validate($options);
         if (!empty($errors)) {
             throw new \Exception(__d('recaptcha', 'One of your recaptcha config value is incorrect'));
             // throw an exception with config error that is raised
@@ -137,7 +137,7 @@ class RecaptchaHelper extends Helper
 
         // Validate the Configure Data
         $validator = new RecaptchaValidator();
-        $errors = $validator->errors($options);
+        $errors = $validator->validate($options);
         if (!empty($errors)) {
             throw new \Exception(__d('recaptcha', 'One of your recaptcha config value is incorrect in a widget'));
             // throw an exception with config error that is raised

--- a/src/View/Helper/RecaptchaHelper.php
+++ b/src/View/Helper/RecaptchaHelper.php
@@ -67,7 +67,7 @@ class RecaptchaHelper extends Helper
         }
         // Validate the Configure Data
         $validator = new RecaptchaValidator();
-        $errors = $validator->errors($this->getConfig());
+        $errors = $validator->validate($this->getConfig());
         if (!empty($errors)) {
             throw new \Exception(__d('recaptcha', 'One of your recaptcha config value is incorrect'));
             // throw an exception with config error that is raised

--- a/tests/TestCase/Validation/ConfigValidatorTest.php
+++ b/tests/TestCase/Validation/ConfigValidatorTest.php
@@ -26,22 +26,22 @@ class ConfigValidatorTest extends TestCase
     {
         $validator = new ConfigValidator();
         $data = ['lang' => 'fr'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('secret', $errors);
 
         $validator = new ConfigValidator();
         $data = ['theme' => 'light'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('secret', $errors);
 
         $validator = new ConfigValidator();
         $data = ['type' => 'image'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('secret', $errors);
 
         $validator = new ConfigValidator();
         $data = ['size' => 'normal'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('secret', $errors);
     }
 
@@ -54,22 +54,22 @@ class ConfigValidatorTest extends TestCase
     {
         $validator = new ConfigValidator();
         $data = ['secret' => 'fff', 'lang' => 'fr'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
 
         $validator = new ConfigValidator();
         $data = ['secret' => 'fff', 'theme' => 'light'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
 
         $validator = new ConfigValidator();
         $data = ['secret' => 'fff', 'type' => 'image'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
 
         $validator = new ConfigValidator();
         $data = ['secret' => 'fff', 'size' => 'normal'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
     }
 
@@ -82,22 +82,22 @@ class ConfigValidatorTest extends TestCase
     {
         $validator = new ConfigValidator();
         $data = ['secret' => 'fff', 'lang' => 'non-existing-lang'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('lang', $errors);
 
         $validator = new ConfigValidator();
         $data = ['secret' => 'fff', 'theme' => 'non-existing-theme'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('theme', $errors);
 
         $validator = new ConfigValidator();
         $data = ['secret' => 'fff', 'type' => 'non-existing-type'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('type', $errors);
 
         $validator = new ConfigValidator();
         $data = ['secret' => 'fff', 'size' => 'non-existing-size'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('size', $errors);
     }
 

--- a/tests/TestCase/Validation/GlobalValidatorTest.php
+++ b/tests/TestCase/Validation/GlobalValidatorTest.php
@@ -26,22 +26,22 @@ class GlobalValidatorTest extends TestCase
     {
         $validator = new GlobalValidator();
         $data = ['lang' => 'fr'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
 
         $validator = new GlobalValidator();
         $data = ['theme' => 'light'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
 
         $validator = new GlobalValidator();
         $data = ['type' => 'image'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
 
         $validator = new GlobalValidator();
         $data = ['size' => 'normal'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
     }
 
@@ -54,22 +54,22 @@ class GlobalValidatorTest extends TestCase
     {
         $validator = new GlobalValidator();
         $data = ['lang' => 'non-existing-lang'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('lang', $errors);
 
         $validator = new GlobalValidator();
         $data = ['theme' => 'non-existing-theme'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('theme', $errors);
 
         $validator = new GlobalValidator();
         $data = ['type' => 'non-existing-type'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('type', $errors);
 
         $validator = new GlobalValidator();
         $data = ['size' => 'non-existing-size'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('size', $errors);
     }
 
@@ -87,7 +87,7 @@ class GlobalValidatorTest extends TestCase
             'type' => 'audio',
             'size' => 'compact'
         ];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
     }
 
@@ -105,7 +105,7 @@ class GlobalValidatorTest extends TestCase
             'type' => 'non-existing-type',
             'size' => 'non-existing-size'
         ];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('lang', $errors);
         $this->assertArrayHasKey('theme', $errors);
         $this->assertArrayHasKey('type', $errors);

--- a/tests/TestCase/Validation/RecaptchaValidatorTest.php
+++ b/tests/TestCase/Validation/RecaptchaValidatorTest.php
@@ -26,22 +26,22 @@ class RecaptchaValidatorTest extends TestCase
     {
         $validator = new RecaptchaValidator();
         $data = ['lang' => 'fr'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
 
         $validator = new RecaptchaValidator();
         $data = ['theme' => 'light'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
 
         $validator = new RecaptchaValidator();
         $data = ['type' => 'image'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
 
         $validator = new RecaptchaValidator();
         $data = ['size' => 'normal'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
     }
 
@@ -54,22 +54,22 @@ class RecaptchaValidatorTest extends TestCase
     {
         $validator = new RecaptchaValidator();
         $data = ['lang' => 'non-existing-lang'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('lang', $errors);
 
         $validator = new RecaptchaValidator();
         $data = ['theme' => 'non-existing-theme'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('theme', $errors);
 
         $validator = new RecaptchaValidator();
         $data = ['type' => 'non-existing-type'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('type', $errors);
 
         $validator = new RecaptchaValidator();
         $data = ['size' => 'non-existing-size'];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('size', $errors);
     }
 
@@ -87,7 +87,7 @@ class RecaptchaValidatorTest extends TestCase
             'type' => 'audio',
             'size' => 'compact'
         ];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertEmpty($errors);
     }
 
@@ -105,7 +105,7 @@ class RecaptchaValidatorTest extends TestCase
             'type' => 'non-existing-type',
             'size' => 'non-existing-size'
         ];
-        $errors = $validator->errors($data);
+        $errors = $validator->validate($data);
         $this->assertArrayHasKey('lang', $errors);
         $this->assertArrayHasKey('theme', $errors);
         $this->assertArrayHasKey('type', $errors);


### PR DESCRIPTION
Updated multiple files for CakePHP 4.x

`Validator::errors()` is deprecated. Use `Validator::validate()` instead.